### PR TITLE
Gjort tilpassninger for å fungere bedre sammen med den nye Dekoratøren

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,6 @@ COPY ./ ./
 
 RUN npm install && npm run build
 
-RUN npm install serve
-RUN yarn global add serve
-
-ENV PORT=5000
-EXPOSE $PORT
+EXPOSE 5000
 
 CMD [ "npm", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN yarn global add serve
 ENV PORT=5000
 EXPOSE $PORT
 
-CMD ["serve", "-s", "build"]
+CMD [ "npm", "start" ]

--- a/src/App.js
+++ b/src/App.js
@@ -2,34 +2,40 @@ import React, {Component} from 'react';
 import Cookies from 'js-cookie'
 
 let cookieName = 'selvbetjening-idtoken';
-let dittNavUrl = 'http://localhost:9002';
-let redirectTo = "http://localhost:5000/callback";
+let autoRedirectToFrontend = process.env.REACT_APP_AUTO_REDIRECT_TO_FRONTEND === "true" ? true : false;
+let redirectToFrontend = process.env.REACT_APP_REDIRECT_URL ? process.env.REACT_APP_REDIRECT_URL : 'http://localhost:9002';
+let oidcProviderGuiUrl = "http://localhost:5000/callback";
 let oidcProviderBaseUrl = 'http://localhost:9000';
 let audience = "stubOidcClient";
 let clientSecret = "secretsarehardtokeep";
 let authenticationHeader = new Buffer(audience + ":" + clientSecret).toString('base64');
-let redirectToInitTokenFlow = oidcProviderBaseUrl + "/auth?client_id=" + audience + "&redirect_uri=" + redirectTo + "&response_type=code&scope=openid+profile+acr+email&nonce=123";
+let redirectToInitTokenFlow = oidcProviderBaseUrl + "/auth?client_id=" + audience + "&redirect_uri=" + oidcProviderGuiUrl + "&response_type=code&scope=openid+profile+acr+email&nonce=123";
 
 class App extends Component {
+
     state = {
         idToken: "",
     };
 
-    redirectToAuthenticationPage(sikkerhetsnivaa) {
-        window.location.assign(`${redirectToInitTokenFlow}&acr_values=${sikkerhetsnivaa}`);
-    }
-
-    redirectToDittNav() {
-        window.location.assign(`${dittNavUrl}`);
-    }
-
-    setCookie() {
-        if (this.state.idToken) {
-            Cookies.set('selvbetjening-idtoken', this.state.idToken);
-        } else {
-            console.log('Error: missing token');
+    componentDidMount() {
+        this.deleteCookieIfCurrentUrlSpecifiesLogout();
+        this.updateIdTokenOnState(this.getCookieValue());
+        let code = this.extractCodeFromUrl();
+        if (code) {
+            console.log("Code: " + code);
+            this.fetchActualToken(code, oidcProviderBaseUrl + '/token');
         }
-        console.log('Error: missing token');
+    }
+
+    deleteCookieIfCurrentUrlSpecifiesLogout() {
+        let currentUrl = window.location.href;
+        if (this.isLogOutUrl(currentUrl)) {
+            this.deleteCookie();
+        }
+    }
+
+    isLogOutUrl(currentUrl) {
+        return currentUrl.indexOf("?logout") !== -1;
     }
 
     deleteCookie() {
@@ -39,40 +45,19 @@ class App extends Component {
         }
     }
 
-    componentDidMount() {
-        let code = this.extractCodeFromUrl();
-        if (code) {
-            console.log("Code: " + code);
-            this.fetchActualToken(code, oidcProviderBaseUrl + '/token');
+    getCookieValue() {
+        let cookie = Cookies.get(cookieName);
+        if (cookie) {
+            return cookie;
+        } else {
+            return "Cookie-en " + cookieName + " er ikke satt. Velg innloggingsnivå over, for å sette cookie-en.";
         }
     }
 
-    render() {
-        return (
-            <div>
-                <button onClick={() => this.redirectToAuthenticationPage("Level3")}>
-                    Token for nivå 3
-                </button>
-                <button onClick={() => this.redirectToAuthenticationPage("Level4")}>
-                    Token for nivå 4
-                </button>
-
-                <div>
-                    <textarea name="idToken" id="idToken" cols="100" rows="10"
-                              defaultValue={this.state.idToken != null ? this.state.idToken : "Token har ikke blitt hentet"}/><br/>
-                </div>
-
-                <button onClick={() => this.setCookie()}>
-                    Sett cookie
-                </button>
-                <button onClick={() => this.redirectToDittNav()}>
-                    Redirect to DittNAV
-                </button>
-                <button onClick={() => this.deleteCookie()}>
-                    Slett cookie
-                </button>
-            </div>
-        );
+    updateIdTokenOnState(tokenValue) {
+        this.setState(prevState => ({
+            idToken: tokenValue
+        }));
     }
 
     extractCodeFromUrl() {
@@ -99,7 +84,7 @@ class App extends Component {
                 'Content-Type': 'application/x-www-form-urlencoded',
                 Authorization: 'Basic ' + authenticationHeader
             },
-            body: 'grant_type=authorization_code&code=' + code + '&redirect_uri=' + redirectTo + '&client_secret=' + clientSecret.toString("base64"),
+            body: 'grant_type=authorization_code&code=' + code + '&redirect_uri=' + oidcProviderGuiUrl + '&client_secret=' + clientSecret.toString("base64"),
         })
             .then(response => {
                 if (response.ok) {
@@ -110,10 +95,10 @@ class App extends Component {
             .then(json => {
                 if (json != null) {
                     let idToken = this.removeSurroundingFnutts(json);
-                    this.setState(prevState => ({
-                        idToken: idToken
-                    }));
+                    this.updateIdTokenOnState(idToken)
+                    this.setCookie();
                     console.log("Complete token response:\n" + JSON.stringify(json))
+                    this.performAutoRedirectToFrontendIfEnabled();
                 }
                 return json;
             })
@@ -124,6 +109,51 @@ class App extends Component {
     removeSurroundingFnutts(json) {
         return JSON.stringify(json.id_token).replace("\"", "").replace("\"", "");
     }
+
+    setCookie() {
+        if (this.state.idToken) {
+            Cookies.set(cookieName, this.state.idToken);
+        } else {
+            console.log('Error: missing token');
+        }
+    }
+
+    performAutoRedirectToFrontendIfEnabled() {
+        if (autoRedirectToFrontend) {
+            this.redirectToFrontend();
+        }
+    }
+
+    render() {
+        return (
+            <div>
+                <button onClick={() => this.redirectToAuthenticationPage("Level3")}>
+                    Token for nivå 3
+                </button>
+                <button onClick={() => this.redirectToAuthenticationPage("Level4")}>
+                    Token for nivå 4
+                </button>
+
+                <div>
+                    <textarea name="idToken" id="idToken" cols="100" rows="10"
+                              defaultValue={this.state.idToken != null ? this.state.idToken : "Token har ikke blitt hentet"}/><br/>
+                </div>
+
+                <button onClick={() => this.redirectToFrontend()}>
+                    Redirect to frontend
+                </button>
+            </div>
+        );
+    }
+
+    redirectToAuthenticationPage(sikkerhetsnivaa) {
+        window.location.assign(`${redirectToInitTokenFlow}&acr_values=${sikkerhetsnivaa}`);
+    }
+
+    redirectToFrontend() {
+        window.location.assign(`${redirectToFrontend}`);
+    }
+
 }
 
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -1,15 +1,15 @@
 import React, {Component} from 'react';
 import Cookies from 'js-cookie'
 
-let tokenCookieName = 'selvbetjening-idtoken';
-let autoRedirectToFrontend = process.env.REACT_APP_AUTO_REDIRECT_TO_FRONTEND === "true" ? true : true;
-let redirectToFrontendUrl = process.env.REACT_APP_REDIRECT_URL ? process.env.REACT_APP_REDIRECT_URL : 'http://localhost:8090';
-let oidcProviderGuiUrl = "http://localhost:5000/callback";
-let oidcProviderBaseUrl = 'http://localhost:9000';
-let audience = "stubOidcClient";
-let clientSecret = "secretsarehardtokeep";
-let authenticationHeader = new Buffer(audience + ":" + clientSecret).toString('base64');
-let redirectToInitTokenFlow = oidcProviderBaseUrl + "/auth?client_id=" + audience + "&redirect_uri=" + oidcProviderGuiUrl + "&response_type=code&scope=openid+profile+acr+email&nonce=123";
+const tokenCookieName = 'selvbetjening-idtoken';
+const autoRedirectToFrontend = process.env.REACT_APP_AUTO_REDIRECT_TO_FRONTEND === "true" ? true : true;
+const redirectToFrontendUrl = process.env.REACT_APP_REDIRECT_URL ? process.env.REACT_APP_REDIRECT_URL : 'http://localhost:8090';
+const oidcProviderGuiUrl = "http://localhost:5000/callback";
+const oidcProviderBaseUrl = 'http://localhost:9000';
+const audience = "stubOidcClient";
+const clientSecret = "secretsarehardtokeep";
+const authenticationHeader = new Buffer(audience + ":" + clientSecret).toString('base64');
+const redirectToInitTokenFlow = oidcProviderBaseUrl + "/auth?client_id=" + audience + "&redirect_uri=" + oidcProviderGuiUrl + "&response_type=code&scope=openid+profile+acr+email&nonce=123";
 
 class App extends Component {
 

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import React, {Component} from 'react';
 import Cookies from 'js-cookie'
 
 const tokenCookieName = 'selvbetjening-idtoken';
-const autoRedirectToFrontend = process.env.REACT_APP_AUTO_REDIRECT_TO_FRONTEND === "true" ? true : true;
+const autoRedirectToFrontend = process.env.REACT_APP_AUTO_REDIRECT_TO_FRONTEND === "true" ? true : false;
 const redirectToFrontendUrl = process.env.REACT_APP_REDIRECT_URL ? process.env.REACT_APP_REDIRECT_URL : 'http://localhost:8090';
 const oidcProviderGuiUrl = "http://localhost:5000/callback";
 const oidcProviderBaseUrl = 'http://localhost:9000';

--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,9 @@
 import React, {Component} from 'react';
 import Cookies from 'js-cookie'
 
-let cookieName = 'selvbetjening-idtoken';
-let autoRedirectToFrontend = process.env.REACT_APP_AUTO_REDIRECT_TO_FRONTEND === "true" ? true : false;
-let redirectToFrontend = process.env.REACT_APP_REDIRECT_URL ? process.env.REACT_APP_REDIRECT_URL : 'http://localhost:9002';
+let tokenCookieName = 'selvbetjening-idtoken';
+let autoRedirectToFrontend = process.env.REACT_APP_AUTO_REDIRECT_TO_FRONTEND === "true" ? true : true;
+let redirectToFrontendUrl = process.env.REACT_APP_REDIRECT_URL ? process.env.REACT_APP_REDIRECT_URL : 'http://localhost:8090';
 let oidcProviderGuiUrl = "http://localhost:5000/callback";
 let oidcProviderBaseUrl = 'http://localhost:9000';
 let audience = "stubOidcClient";
@@ -19,7 +19,7 @@ class App extends Component {
 
     componentDidMount() {
         this.deleteCookieIfCurrentUrlSpecifiesLogout();
-        this.updateIdTokenOnState(this.getCookieValue());
+        this.updateIdTokenOnState(this.getTokenCookieValue());
         let code = this.extractCodeFromUrl();
         if (code) {
             console.log("Code: " + code);
@@ -30,7 +30,7 @@ class App extends Component {
     deleteCookieIfCurrentUrlSpecifiesLogout() {
         let currentUrl = window.location.href;
         if (this.isLogOutUrl(currentUrl)) {
-            this.deleteCookie();
+            this.deleteTokenCookie();
         }
     }
 
@@ -38,19 +38,19 @@ class App extends Component {
         return currentUrl.indexOf("?logout") !== -1;
     }
 
-    deleteCookie() {
-        let cookie = Cookies.get(cookieName);
+    deleteTokenCookie() {
+        let cookie = Cookies.get(tokenCookieName);
         if (cookie) {
-            Cookies.remove(cookieName);
+            Cookies.remove(tokenCookieName);
         }
     }
 
-    getCookieValue() {
-        let cookie = Cookies.get(cookieName);
+    getTokenCookieValue() {
+        let cookie = Cookies.get(tokenCookieName);
         if (cookie) {
             return cookie;
         } else {
-            return "Cookie-en " + cookieName + " er ikke satt. Velg innloggingsnivå over, for å sette cookie-en.";
+            return "Cookie-en " + tokenCookieName + " er ikke satt. Velg innloggingsnivå over, for å sette cookie-en.";
         }
     }
 
@@ -96,7 +96,7 @@ class App extends Component {
                 if (json != null) {
                     let idToken = this.removeSurroundingFnutts(json);
                     this.updateIdTokenOnState(idToken)
-                    this.setCookie();
+                    this.setTokenCookie();
                     console.log("Complete token response:\n" + JSON.stringify(json))
                     this.performAutoRedirectToFrontendIfEnabled();
                 }
@@ -110,9 +110,9 @@ class App extends Component {
         return JSON.stringify(json.id_token).replace("\"", "").replace("\"", "");
     }
 
-    setCookie() {
+    setTokenCookie() {
         if (this.state.idToken) {
-            Cookies.set(cookieName, this.state.idToken);
+            Cookies.set(tokenCookieName, this.state.idToken);
         } else {
             console.log('Error: missing token');
         }
@@ -151,7 +151,7 @@ class App extends Component {
     }
 
     redirectToFrontend() {
-        window.location.assign(`${redirectToFrontend}`);
+        window.location.assign(`${redirectToFrontendUrl}`);
     }
 
 }


### PR DESCRIPTION
* Lagt til støtte for å konfigurere hvilken frontend det skal redirectes tilbake til
* Lagt til støtte for å konfigurere om det skal redirectes automatisk tilbake til den konfigurerte frontend-en i det det har blitt hetet et token.
* Lagt til støtte for å simulere utlogging.
* Ved lasting av denne frontend-en vil den vise innholdet i token-cookie-en hvis den er tilgjengelig.

NB! Appen kjører nå i development-mode inne i docker-image-et, for at man skal kunne konfigurere appen via miljøvariabler. Dette er ikke helt optimalt, men dette er uansett en app som kun skal brukes underveis i utvikling.

PB-307. Tilpasse dekoratøren til å kunne brukes i docker-compose