### PR TITLE
Kjøring i prod-modus med miljøvariabelstøtte

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 node_modules
 build
 .idea
+docker-compose.yml
+public/config.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,16 @@
 FROM node:carbon
 
-COPY ./ ./
+COPY ./ /app
+WORKDIR /app
 
 RUN npm install && npm run build
 
+RUN npm install serve
+RUN yarn global add serve
+
 EXPOSE 5000
 
-CMD [ "npm", "start" ]
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT /entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+if [[ -z "$REDIRECT_URL" ]] || [[ -z "$AUTO_REDIRECT_TO_FRONTEND" ]] ; then
+  echo "For å kunne starte applikasjonen må miljøvariablene REDIRECT_URL og AUTO_REDIRECT_TO_FRONTEND være satt."
+  echo "Avbryter oppstart."
+  exit 1
+fi
+
+TEST_CONFIG_FILE=./public/config.js
+if test -f "${TEST_CONFIG_FILE}"; then
+    echo "Warning: Test-konfig-en ${TEST_CONFIG_FILE} har feilaktig kommet med i docker-image-et."
+    echo "  Sørg for at prosjektets .dockerignore-fil innholder 'public/config.js' slik at dette ikke skjer igjen."
+    echo "  Sletter ${TEST_CONFIG_FILE} som ligger i image-et, slik at inneværende skript kan opprette en koorekt config.js-fil basert på miljøvariabler."
+    rm ${TEST_CONFIG_FILE}
+fi
+
+echo "Tilgjengeliggjør følgende miljøvariabler for frontend-en:"
+echo "* REDIRECT_URL"
+echo "* AUTO_REDIRECT_TO_FRONTEND"
+
+echo "window.env={};" > /app/build/config.js
+echo "window.env.REDIRECT_URL=\"$REDIRECT_URL\";" >> /app/build/config.js
+echo "window.env.AUTO_REDIRECT_TO_FRONTEND=\"$AUTO_REDIRECT_TO_FRONTEND\";" >> /app/build/config.js
+
+echo "Starter frontend-en"
+serve -s build

--- a/public/config.js
+++ b/public/config.js
@@ -1,0 +1,4 @@
+console.log("Setter nødvendige variabler for å kunne kjøre i testmodus");
+window.env = {};
+window.env.REDIRECT_URL="http://localhost:8090";
+window.env.AUTO_REDIRECT_TO_FRONTEND="false";

--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <script src="%PUBLIC_URL%/config.js"></script>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -24,7 +25,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>OIDC-provider-GUI</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.js
+++ b/src/App.js
@@ -2,8 +2,8 @@ import React, {Component} from 'react';
 import Cookies from 'js-cookie'
 
 const tokenCookieName = 'selvbetjening-idtoken';
-const autoRedirectToFrontend = process.env.REACT_APP_AUTO_REDIRECT_TO_FRONTEND === "true" ? true : false;
-const redirectToFrontendUrl = process.env.REACT_APP_REDIRECT_URL ? process.env.REACT_APP_REDIRECT_URL : 'http://localhost:8090';
+const autoRedirectToFrontend = window.env.AUTO_REDIRECT_TO_FRONTEND === "true" ? true : false;
+const redirectToFrontendUrl = window.env.REDIRECT_URL ? window.env.REDIRECT_URL : 'http://localhost:8090';
 const oidcProviderGuiUrl = "http://localhost:5000/callback";
 const oidcProviderBaseUrl = 'http://localhost:9000';
 const audience = "stubOidcClient";


### PR DESCRIPTION
Appen kjøres nå i produksjons-optimalisert modus med statiske filer, og har fått støtte for konfig via miljøvariabler.

* Appen startes med et entrypoint-skript som leser inn miløvariabler, og skriver disse til en javascript-fil som vil bli tilgjengelig i appen. Dette gjør at appen kan konfigureres med verdiene som opprinnelig kommer fra miljøvariabler.
* Ved lokal kjøring er det en egen config.js-fil med default-verdier, denne er det IKKE meningen at skal bli med i docker-image-et. For å unngå dette er denne filen lagt til i .dockerignore-filen. Hvis denne feilen mot formodning skulle komme med, så vil dette snappes opp i entrypoint.sh og det vil bli logget en advarsel og filen vil bli slettet. Det vil uansett bli opprettet en config.js-fil basert på miljøvariablene som blir sendt inn til appen.